### PR TITLE
Issue 32

### DIFF
--- a/noodles/__init__.py
+++ b/noodles/__init__.py
@@ -2,10 +2,13 @@ from noodles.interface import (
     delay, gather, lift, schedule, schedule_hint, unwrap,
     has_scheduled_methods, update_hints, unpack)
 from .eval_data import Lambda
+from .run.runner_xenon import (run_xenon, run_xenon_prov)
 from .run.runners import run_parallel_with_display as run_logging
 from .run.runners import (run_single, run_parallel)
 from .run.process import run_process
 from .run.scheduler import Scheduler
+from .run.xenon import (XenonConfig, RemoteJobConfig, XenonKeeper)
+
 from .storable import Storable
 
 __version__ = "0.2.0"
@@ -13,5 +16,7 @@ __version__ = "0.2.0"
 __all__ = ['schedule', 'schedule_hint', 'run_single', 'run_process',
            'run_logging', 'run_parallel', 'run_hybrid', 'unwrap',
            'Scheduler', 'Storable', 'has_scheduled_methods', 'Lambda',
-           'gather', 'lift', 'unpack', 'delay', 'update_hints']
+           'gather', 'lift', 'unpack', 'delay', 'update_hints',
+           'run_xenon', 'run_xenon_prov', 'XenonConfig',
+           'RemoteJobConfig', 'XenonKeeper']
 

--- a/noodles/run/dynamic_pool.py
+++ b/noodles/run/dynamic_pool.py
@@ -1,8 +1,8 @@
-from ..queue import Queue
-from ..connection import Connection
-from ..coroutine import coroutine
-from ..haploid import (push)
-from ..scheduler import Result
+from .queue import Queue
+from .connection import Connection
+from .coroutine import coroutine
+from .haploid import (push)
+from .scheduler import Result
 
 import xenon
 import jpype

--- a/noodles/run/runner_xenon.py
+++ b/noodles/run/runner_xenon.py
@@ -1,11 +1,11 @@
 from .dynamic_pool import DynamicPool
-from ..scheduler import Scheduler
-from ..job_keeper import JobKeeper
-from ..haploid import (broadcast, sink_map, patch, branch)
-from ..run_with_prov import (prov_wrap_connection)
-from ..queue import Queue
+from .scheduler import Scheduler
+from .job_keeper import JobKeeper
+from .haploid import (broadcast, sink_map, patch, branch)
+from .run_with_prov import (prov_wrap_connection)
+from .queue import Queue
 
-from ...workflow import (get_workflow)
+from ..workflow import (get_workflow)
 
 import threading
 from copy import copy

--- a/noodles/run/xenon.py
+++ b/noodles/run/xenon.py
@@ -1,5 +1,5 @@
 # from ..logger import log
-from ...utility import object_name
+from ..utility import object_name
 from noodles import serial
 # from .hybrid import hybrid_threaded_worker
 

--- a/noodles/run/xenon/__init__.py
+++ b/noodles/run/xenon/__init__.py
@@ -1,5 +1,0 @@
-from .runner import (run_xenon, run_xenon_prov)
-from .xenon import (XenonConfig, RemoteJobConfig, XenonKeeper)
-
-__all__ = ['XenonConfig', 'RemoteJobConfig', 'XenonKeeper',
-           'run_xenon', 'run_xenon_prov']

--- a/test/test_xenon_local.py
+++ b/test/test_xenon_local.py
@@ -1,9 +1,8 @@
 from nose.plugins.skip import SkipTest
 
 try:
-    from noodles.run.xenon import (
-        run_xenon_prov, XenonConfig,
-        RemoteJobConfig, XenonKeeper)
+    from noodles.xenon import (XenonConfig, RemoteJobConfig, XenonKeeper)
+    from noodles.runner_xenon import run_xenon_prov
 
 except ImportError as e:
     raise SkipTest(str(e))


### PR DESCRIPTION
move to content of the xenon folder to its parent the run folder due to the [init-trap](http://python-notes.curiousefficiency.org/en/latest/python_concepts/import_traps.html) issue.