### PR TITLE
Fix dependencies

### DIFF
--- a/noodles/run/xenon/__init__.py
+++ b/noodles/run/xenon/__init__.py
@@ -1,5 +1,13 @@
-from .runner import (run_xenon, run_xenon_prov)
-from .xenon import (XenonConfig, RemoteJobConfig, XenonKeeper)
+from .runner import (run_xenon)
+from .xenon import (XenonJob, XenonScheduler, XenonConfig, RemoteJobConfig,
+                    XenonKeeper)
 
-__all__ = ['XenonConfig', 'RemoteJobConfig', 'XenonKeeper',
-           'run_xenon', 'run_xenon_prov']
+# Only export run_xenon_prov if provenance is installed
+try:
+    from .runner import run_xenon_prov
+    __all__ = ['run_xenon_prov']
+except ImportError:
+    __all__ = []
+
+__all__ += ['XenonConfig', 'XenonJob', 'XenonScheduler', 'RemoteJobConfig',
+            'XenonKeeper', 'run_xenon']

--- a/noodles/run/xenon/runner.py
+++ b/noodles/run/xenon/runner.py
@@ -2,13 +2,83 @@ from .dynamic_pool import DynamicPool
 from ..scheduler import Scheduler
 from ..job_keeper import JobKeeper
 from ..haploid import (broadcast, sink_map, patch, branch)
-from ..run_with_prov import (prov_wrap_connection)
 from ..queue import Queue
 
 from ...workflow import (get_workflow)
 
 import threading
 from copy import copy
+
+# Only define run_xenon_prov if provenance is installed
+try:
+    from ..run_with_prov import prov_wrap_connection
+except ImportError:
+    pass
+else:
+    def run_xenon_prov(wf, Xe, jobdb_file, n_processes, xenon_config,
+                       job_config, *, deref=False, job_keeper=None, display=None):
+        """Run the workflow using a number of online Xenon workers.
+
+        :param Xe:
+            The XenonKeeper instance.
+
+        :param wf:
+            The workflow.
+        :type wf: `Workflow` or `PromisedObject`
+
+        :param n_processes:
+            Number of processes to start.
+
+        :param xenon_config:
+            The :py:class:`XenonConfig` object that gives tells us how to use
+            Xenon.
+
+        :param job_config:
+            The :py:class:`RemoteJobConfig` object that specifies the command to
+            run remotely for each worker.
+
+        :param deref:
+            Set this to True to pass the result through one more encoding and
+            decoding step with object derefencing turned on.
+        :type deref: bool
+
+        :returns: the result of evaluating the workflow
+        :rtype: any
+        """
+        DP = DynamicPool(Xe, xenon_config)
+
+        for i in range(n_processes):
+            cfg = copy(job_config)
+            cfg.name = 'xenon-{0:02}'.format(i)
+            DP.add_xenon_worker(cfg)
+
+        if job_keeper is None:
+            job_keeper = JobKeeper()
+        S = Scheduler(job_keeper=job_keeper)
+
+        LogQ = Queue()
+        if display:
+            tgt = broadcast(job_keeper.message, sink_map(display))
+        else:
+            tgt = job_keeper.message
+
+        threading.Thread(
+            target=patch,
+            args=(LogQ.source, tgt),
+            daemon=True).start()
+
+        result = S.run(
+            prov_wrap_connection(
+                DP >> branch(LogQ.sink),
+                DP.result_queue, job_config.registry,
+                jobdb_file, job_keeper,
+                log_q=LogQ),
+            get_workflow(wf))
+
+        if deref:
+            return job_config.registry().dereference(result, host='localhost')
+        else:
+            return result
 
 
 def run_xenon(wf, Xe, jobdb_file, n_processes, xenon_config,
@@ -76,73 +146,6 @@ def run_xenon(wf, Xe, jobdb_file, n_processes, xenon_config,
     #         jobdb_file, job_keeper,
     #         log_q=LogQ),
     #     get_workflow(wf))
-
-    if deref:
-        return job_config.registry().dereference(result, host='localhost')
-    else:
-        return result
-
-
-def run_xenon_prov(wf, Xe, jobdb_file, n_processes, xenon_config,
-                   job_config, *, deref=False, job_keeper=None, display=None):
-    """Run the workflow using a number of online Xenon workers.
-
-    :param Xe:
-        The XenonKeeper instance.
-
-    :param wf:
-        The workflow.
-    :type wf: `Workflow` or `PromisedObject`
-
-    :param n_processes:
-        Number of processes to start.
-
-    :param xenon_config:
-        The :py:class:`XenonConfig` object that gives tells us how to use
-        Xenon.
-
-    :param job_config:
-        The :py:class:`RemoteJobConfig` object that specifies the command to
-        run remotely for each worker.
-
-    :param deref:
-        Set this to True to pass the result through one more encoding and
-        decoding step with object derefencing turned on.
-    :type deref: bool
-
-    :returns: the result of evaluating the workflow
-    :rtype: any
-    """
-
-    DP = DynamicPool(Xe, xenon_config)
-
-    for i in range(n_processes):
-        cfg = copy(job_config)
-        cfg.name = 'xenon-{0:02}'.format(i)
-        DP.add_xenon_worker(cfg)
-
-    if job_keeper is None:
-        job_keeper = JobKeeper()
-    S = Scheduler(job_keeper=job_keeper)
-
-    LogQ = Queue()
-    if display:
-        tgt = broadcast(job_keeper.message, sink_map(display))
-    else:
-        tgt = job_keeper.message
-
-    threading.Thread(
-        target=patch,
-        args=(LogQ.source, tgt),
-        daemon=True).start()
-
-    result = S.run(
-        prov_wrap_connection(
-            DP >> branch(LogQ.sink),
-            DP.result_queue, job_config.registry,
-            jobdb_file, job_keeper,
-            log_q=LogQ),
-        get_workflow(wf))
 
     if deref:
         return job_config.registry().dereference(result, host='localhost')

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(
     extras_require={
         'prov': ['tinydb'],
         'xenon': ['pyxenon'],
-        'test': ['nose', 'coverage', 'pyflakes', 'pep8']
+        'test': ['nose', 'coverage', 'pyflakes', 'pep8', 'docker-py']
     },
 )

--- a/test/test_prov.py
+++ b/test/test_prov.py
@@ -4,7 +4,6 @@ try:
     from noodles.prov import prov_key
     from noodles.run.run_with_prov import (
         run_single, run_parallel, run_parallel_opt)
-
 except ImportError as e:
     raise SkipTest(str(e))
 

--- a/test/test_xenon_local.py
+++ b/test/test_xenon_local.py
@@ -1,12 +1,16 @@
 from nose.plugins.skip import SkipTest
 
 try:
-    from noodles.run.xenon import (
-        run_xenon_prov, XenonConfig,
-        RemoteJobConfig, XenonKeeper)
-
+    # Only test xenon if it is installed
+    from noodles.run.xenon import (XenonConfig, RemoteJobConfig, XenonKeeper)
 except ImportError as e:
     raise SkipTest(str(e))
+else:
+    # Only test run_xenon_prov if provenance is installed, otherwise run_xenon
+    try:
+        from noodles.run.xenon import run_xenon_prov as run_xenon
+    except ImportError:
+        from noodles.run.xenon import run_xenon
 
 import noodles
 from noodles.display import (NCDisplay)
@@ -36,7 +40,7 @@ def test_xenon_42():
     )
 
     with XenonKeeper() as Xe, NCDisplay() as display:
-        result = run_xenon_prov(
+        result = run_xenon(
             C, Xe, "cache.json", 2, xenon_config, job_config,
             display=display)
 


### PR DESCRIPTION
Since provenance is optional, the tests with Xenon failed with import errors. Fixed the import errors.
Also `docker-py` is now added to the `test`-dependencies.