### PR TITLE
 #54 return list of promised objects instead of a single promise

### DIFF
--- a/noodles/__init__.py
+++ b/noodles/__init__.py
@@ -2,7 +2,7 @@ from noodles.interface import (
     delay, gather, lift, schedule, schedule_hint, unwrap,
     has_scheduled_methods, update_hints, unpack, quote, unquote,
     gather_dict, result, gather_all, maybe, Fail)
-from .patterns import (filter, fold)
+from .patterns import (find_first)
 from .run.runners import run_parallel_with_display as run_logging
 from .run.runners import (run_single, run_parallel)
 from .run.process import run_process
@@ -14,5 +14,6 @@ __version__ = "0.2.3"
 __all__ = ['schedule', 'schedule_hint', 'run_single', 'run_process',
            'run_logging', 'run_parallel', 'unwrap',
            'Scheduler', 'Storable', 'has_scheduled_methods', 'Fail',
-           'gather', 'gather_all', 'gather_dict', 'lift', 'unpack', 'maybe',
+           'find_first', 'gather', 'gather_all', 'gather_dict',
+           'lift', 'unpack', 'maybe',
            'delay', 'update_hints', 'quote', 'unquote', 'result']

--- a/noodles/patterns/__init__.py
+++ b/noodles/patterns/__init__.py
@@ -1,8 +1,9 @@
 from .control_flow_statements import (
     if_predicate)
 from .find_first import (find_first)
-from .functional_patterns import (all, any, filter, fold, map, zip_with)
+from .functional_patterns import (
+    all, any, filter, first, fold, map, second, zip_with)
 
 __all__ = [
-    'all', 'any', 'filter', 'fold', 'find_first', 'if_predicate', 'map',
-    'zip_with']
+    'all', 'any', 'filter', 'fold', 'find_first', 'first', 'if_predicate',
+    'map', 'second', 'zip_with']

--- a/noodles/patterns/functional_patterns.py
+++ b/noodles/patterns/functional_patterns.py
@@ -89,7 +89,7 @@ def fold(
     def generator(state):
         rs = []
         for x in xs:
-            state, r = fun(state, x)
+            state, r = unpack(fun(state, x), 2)
             rs.append(r)
 
         return state, rs

--- a/noodles/patterns/functional_patterns.py
+++ b/noodles/patterns/functional_patterns.py
@@ -1,6 +1,6 @@
 from .find_first import find_first
-from noodles import (gather, schedule, unpack)
-from typing import (Any, Callable, Iterable)
+from noodles import (schedule, unpack)
+from typing import (Any, Callable, Iterable, Tuple)
 
 
 @schedule
@@ -51,7 +51,23 @@ def filter(pred: Callable, xs: Iterable):
     """
     generator = (x for x in xs if pred(x))
 
-    return gather(*generator)
+    return list(generator)
+
+
+def first(promise: Tuple):
+    """
+    Get the first value of a promised Tuple.
+    """
+    x, _ = unpack(promise, 2)
+    return x
+
+
+def second(promise: Tuple):
+    """
+    Get the second value of a promise Tuple.
+    """
+    _, y = unpack(promise, 2)
+    return y
 
 
 @schedule
@@ -71,11 +87,14 @@ def fold(
     :returns: :py:class:`PromisedObject`
     """
     def generator(state):
+        rs = []
         for x in xs:
-            state, r = unpack(fun(state, x), 2)
-            yield r
+            state, r = fun(state, x)
+            rs.append(r)
 
-    return gather(*generator(state))
+        return state, rs
+
+    return generator(state)
 
 
 @schedule
@@ -92,9 +111,7 @@ def map(fun: Callable, xs: Iterable):
 
     returns::py:class:`PromisedObject`
     """
-    generator = (fun(x) for x in xs)
-
-    return gather(*generator)
+    return list(fun(x) for x in xs)
 
 
 @schedule
@@ -116,6 +133,4 @@ def zip_with(fun: Callable, xs: Iterable, ys: Iterable):
 
     returns::py:class:`PromisedObject`
     """
-    generator = (fun(*rs) for rs in zip(xs, ys))
-
-    return gather(*generator)
+    return list(fun(*rs) for rs in zip(xs, ys))

--- a/test/test_patterns.py
+++ b/test/test_patterns.py
@@ -19,9 +19,10 @@ def test_pattern():
 def create_wf_1():
     arr = np.random.normal(size=100)
     xs = patterns.fold(aux_sum, 0, arr)
-    ys = patterns.map(lambda x: x ** 2, xs)
+    ys = patterns.map(lambda x: x ** 2, patterns.second(xs))
 
-    return schedule_allclose(ys, np.cumsum(arr) ** 2)
+    return schedule_allclose(
+        ys, np.cumsum(arr) ** 2)
 
 
 def create_wf_2():
@@ -37,7 +38,8 @@ def create_wf_3():
     ys = patterns.map(lambda x: np.pi * x, arr)
     rs = patterns.zip_with(x_sin_pix, arr, ys)
 
-    return schedule_allclose(rs, arr * np.sin(np.pi * arr))
+    return schedule_allclose(
+        rs, arr * np.sin(np.pi * arr))
 
 
 def create_wf_4():
@@ -45,6 +47,10 @@ def create_wf_4():
     xs = patterns.map(math.cos, arr)
 
     return patterns.any(lambda x: x < 0, xs)
+
+
+def expensive_computation(x):
+    return math.exp(x)
 
 
 def x_sin_pix(x, y):


### PR DESCRIPTION
Returning list of promises instead of a single `PromisedObject` containing an iterator can avoid confusion.