### PR TITLE
added a .zenodo.json file to control metadata on Zenodo

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,50 @@
+{
+    "description": "Task-based parallel programming model in Python. Run complex workflows on large computer clusters or parallelize codes on your laptop: Noodles offers the same intuitive interface.",
+    "license": "Apache-2.0",
+    "title": "Noodles",
+    "upload_type": "software",
+    "creators": [{
+            "affiliation": "Netherlands eScience Center",
+            "name": "Hidding, Johan"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "van Hees, Vincent"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Spreeuw, Hanno"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Zapata, Felipe"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Weel, Berend"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Borgdorff, Joris"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Ridder, Lars"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "van Werkhoven, Ben"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Kuzniar, Arnold",
+            "orcid": "0000-0003-1711-7961"
+        }
+    ],
+    "access_right": "open",
+    "keywords": [
+        "parallel programming",
+        "functional programming",
+        "Python"
+    ]
+}


### PR DESCRIPTION
Hey I'm experimenting a bit with controlling the metadata that gets attached to your releases on Zenodo. In this PR, I've added a new file ``.zenodo.json`` which now includes the contributors from https://github.com/NLeSC/noodles/graphs/contributors as ``creators``. If you also want to include people who make issues and such, there is another field ``contributors`` you can add to the ``.zenodo.json``. Items you include there can have an attribute ``type`` which you can set to ``Other`` or another type from the controlled vocabulary [ContactPerson, DataCollector, DataCurator, DataManager, Editor, Researcher, RightsHolder, Sponsor, Other]. 

Anyway long story short, with this ``.zenodo.json`` file, your release process should be less painful.
-Jurriaan