### PR TITLE
add explicit h5py File mode

### DIFF
--- a/noodles/serial/numpy.py
+++ b/noodles/serial/numpy.py
@@ -80,7 +80,7 @@ class SerNumpyArrayToHDF5(Serialiser):
     def encode(self, obj, make_rec):
         key = array_sha256(obj)
         with self.lock:
-            f = h5py.File(self.filename)
+            f = h5py.File(self.filename, 'a')
             path = next(
                 (ds for ds in f if f[ds].attrs.get('hash') == key),
                 False)
@@ -99,7 +99,7 @@ class SerNumpyArrayToHDF5(Serialiser):
 
     def decode(self, cls, data):
         with self.lock:
-            f = h5py.File(self.filename)
+            f = h5py.File(self.filename, 'r')
             obj = f[data["path"]].value
             f.close()
 


### PR DESCRIPTION
## The issue
In `noodles/serial/numpy` module:
```
noodles/serial/numpy.py:83: H5pyDeprecationWarning: The default file mode will change to 'r' (read-only) in h5py 3.0. To suppress this wa
rning, pass the mode you need to h5py.File(), or set the global default h5.get_config().default_file_mode, or set the environment variable H5PY_DEFAULT_READONLY=1. Available modes are: 'r', 'r+', 'w', 'w
-'/'x', 'a'. See the docs for details.            
```

## Solution
Add explicity the file mode to use