### PR TITLE
ENH: Replace `print` calls with `Logger.log`

### DIFF
--- a/noodles/display/dumb_term.py
+++ b/noodles/display/dumb_term.py
@@ -1,7 +1,11 @@
+import logging
+
 from .pretty_term import OutStream
 from ..workflow import FunctionNode
 from inspect import Parameter
 import sys
+
+logger = logging.getLogger("noodles")
 
 
 def _format_arg_list(a, v):
@@ -32,9 +36,8 @@ class DumbDisplay:
 
     def print_message(self, key, msg):
         if key in self.jobs:
-            print("{1:12} | {2}".format(
-                    key, '['+msg.upper()+']', self.jobs[key]['name']),
-                  file=sys.stderr)
+            logger.info("{1:12} | {2}".format(
+                    key, '['+msg.upper()+']', self.jobs[key]['name']))
 
     def add_job(self, key, name):
         self.jobs[key] = {'name': name}
@@ -50,21 +53,20 @@ class DumbDisplay:
             self.out << "[ERROR!]\n\n"
 
             for job, e in self.errors:
-                msg = 'ERROR '
                 if 'display' in job.hints:
-                    msg += job.hints['display'].format(
+                    msg = job.hints['display'].format(
                         **job.bound_args.arguments)
                 else:
-                    msg += 'calling {} with {}'.format(
+                    msg = 'calling {} with {}'.format(
                         job.foo.__name__, dict(job.bound_args.arguments)
                     )
 
-                print(msg)
+                logger.error(msg)
                 err_msg = self.error_filter(e)
                 if err_msg:
-                    print(err_msg)
+                    logger.error(err_msg)
                 else:
-                    print(e)
+                    logger.error(e)
 
     def __call__(self, msg):
         key, status, data, err = msg
@@ -96,7 +98,10 @@ class DumbDisplay:
                 self.out << "\n" << "User interrupt detected, abnormal exit.\n"
                 return True
 
-            print("Internal error encountered. Contact the developers.")
+            logger.critical(
+                "Internal error encountered. Contact the developers.",
+                exc_info=exc_val,
+            )
             return False
 
         self.report()

--- a/noodles/display/pretty.py
+++ b/noodles/display/pretty.py
@@ -1,4 +1,7 @@
 # from .termapp import TermApp
+import logging
+
+logger = logging.getLogger("noodles")
 
 
 class Display:
@@ -26,8 +29,10 @@ class Display:
             if exc_type is SystemExit:
                 return False
 
-            print("Internal error encountered. Contact the developers: \n",
-                  exc_type, exc_val)
+            logger.critical(
+                "Internal error encountered. Contact the developers",
+                exc_info=exc_val,
+            )
             return False
 
         self.report()

--- a/noodles/display/simple.py
+++ b/noodles/display/simple.py
@@ -1,6 +1,10 @@
 from .pretty_term import OutStream
 import sys
 
+import logging
+
+logger = logging.getLogger("noodles")
+
 
 class Display:
     """A modest display to track jobs being run. The message being printed
@@ -62,37 +66,35 @@ class Display:
                 self.out << "There were warnings: \n\n"
 
                 for job, w in self.messages:
-                    msg = 'WARNING '
                     if job.hints and 'display' in job.hints:
-                        msg += job.hints['display'].format(
+                        msg = job.hints['display'].format(
                             **job.bound_args.arguments)
                     else:
-                        msg += 'calling {} with {}'.format(
+                        msg = 'calling {} with {}'.format(
                             job.foo.__name__, dict(job.bound_args.arguments)
                         )
-                    print(msg)
-                    print(w)
+                    logger.warning(msg)
+                    logger.warning(w)
 
         else:
             self.out << "╰─(" << ['fg', 240, 100, 60] << "ERROR!" \
                      << ['reset'] << ")\n\n"
 
             for job, e in self.errors:
-                msg = 'ERROR '
                 if job.hints and 'display' in job.hints:
-                    msg += job.hints['display'].format(
+                    msg = job.hints['display'].format(
                         **job.bound_args.arguments)
                 else:
-                    msg += 'calling {} with {}'.format(
+                    msg = 'calling {} with {}'.format(
                         job.foo.__name__, dict(job.bound_args.arguments)
                     )
 
-                print(msg)
+                logger.error(msg)
                 err_msg = self.error_filter(e)
                 if err_msg:
-                    print(err_msg)
+                    logger.error(err_msg)
                 else:
-                    print(e)
+                    logger.error(e)
 
     def __call__(self, q):
         self.q = q
@@ -112,7 +114,10 @@ class Display:
                          << ['reset']
                 return True
 
-            print("Internal error encountered. Contact the developers.")
+            logger.critical(
+                "Internal error encountered. Contact the developers.",
+                exc_info=exc_val,
+            )
             return False
 
         self.report()

--- a/noodles/display/simple_nc.py
+++ b/noodles/display/simple_nc.py
@@ -1,5 +1,8 @@
 from .pretty_term import OutStream
 import sys
+import logging
+
+logger = logging.getLogger("noodles")
 
 
 class Display:
@@ -115,16 +118,15 @@ class Display:
                 self.out << "There were warnings: \n\n"
 
                 for job, w in self.messages:
-                    msg = 'WARNING '
                     if job.hints and 'display' in job.hints:
-                        msg += job.hints['display'].format(
+                        msg = job.hints['display'].format(
                             **job.bound_args.arguments)
                     else:
-                        msg += 'calling {} with {}'.format(
+                        msg = 'calling {} with {}'.format(
                             job.foo.__name__, dict(job.bound_args.arguments)
                         )
-                    print(msg)
-                    print(w)
+                    logger.warning(msg)
+                    logger.warning(w)
 
         else:
             self.out << self.chars['line-bl'] << self.chars['line-hor'] \
@@ -132,17 +134,16 @@ class Display:
                      << ['reset'] << ")\n\n"
 
             for job, e in self.errors:
-                msg = 'ERROR '
                 if job.hints and 'display' in job.hints:
-                    msg += job.hints['display'].format(
+                    msg = job.hints['display'].format(
                         **job.bound_args.arguments)
                 else:
-                    msg += 'calling {} with {}'.format(
+                    msg = 'calling {} with {}'.format(
                         job.foo.__name__, dict(job.bound_args.arguments)
                     )
 
-                print(msg)
-                print(e)
+                logger.error(msg)
+                logger.error(e)
 
     def __call__(self, msg):
         key, status, data, err_msg = msg
@@ -164,8 +165,10 @@ class Display:
             if exc_type is SystemExit:
                 return False
 
-            print("Internal error encountered. Contact the developers: \n",
-                  exc_type, exc_val)
+            logger.critical(
+                f"Internal error encountered. Contact the developers.",
+                exc_info=exc_val,
+            )
             return False
 
         self.report()

--- a/noodles/prov/sqlite.py
+++ b/noodles/prov/sqlite.py
@@ -21,6 +21,7 @@ of that workflow with that of the original job. In that case we add a "link"
 once a non-workflow result is known.
 """
 
+import logging
 import sqlite3
 from pathlib import Path
 from threading import Lock
@@ -39,6 +40,8 @@ try:
     import ujson as json
 except ImportError:
     import json
+
+logger = logging.getLogger("noodles")
 
 
 schema = '''
@@ -193,8 +196,8 @@ class JobDB:
             return
 
         if key not in self.jobs:
-            print("WARNING: store_result called but job not in registry:\n"
-                  "   race condition? Not doing anything.\n", file=sys.stderr)
+            logger.warnings("store_result called but job not in registry:\n"
+                            "   race condition? Not doing anything.\n")
             return
 
         with self.lock:

--- a/noodles/run/config.py
+++ b/noodles/run/config.py
@@ -1,6 +1,9 @@
+import logging
 import configparser
 from typing import (List)
 from ..lib import (look_up)
+
+logger = logging.getLogger("noodles")
 
 
 runners = [
@@ -145,7 +148,7 @@ def run_with_config(config_file, workflow, machine=None):
 
     machine = config.get('default', 'machine', fallback=machine)
     if machine is None:
-        print("No machine given, running local in single thread.")
+        logger.info("No machine given, running local in single thread.")
         runner = find_runner(name='single', features=[])
         settings = {}
 

--- a/noodles/run/job_keeper.py
+++ b/noodles/run/job_keeper.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 import time
 import json
@@ -6,6 +7,8 @@ import sys
 from threading import Lock
 from ..lib import (coroutine, EndOfQueue)
 from .messages import (JobMessage, EndOfWork)
+
+logger = logging.getLogger("noodles")
 
 
 class JobKeeper(dict):
@@ -34,8 +37,8 @@ class JobKeeper(dict):
             return
 
         if key not in self:
-            print("WARNING: store_result called but job not in registry:\n"
-                  "   race condition? Not doing anything.\n", file=sys.stderr)
+            logger.warning("store_result called but job not in registry:\n"
+                           "   race condition? Not doing anything.\n")
             return
 
         with self.lock:
@@ -50,8 +53,7 @@ class JobKeeper(dict):
             if msg is EndOfQueue:
                 return
             if msg is None:
-                print("Warning: `None` received where not expected.",
-                      file=sys.stderr)
+                logger.warning("`None` received where not expected.")
                 return
 
             key, status, value, err = msg

--- a/noodles/run/logging.py
+++ b/noodles/run/logging.py
@@ -3,11 +3,33 @@ Provides logging facilities that can be inserted at any place in a system
 of streams.
 """
 
+import sys
 import logging
 
 from ..lib import (EndOfQueue)
 from ..workflow import (is_workflow)
 from .messages import (JobMessage, ResultMessage)
+
+__all__ = ["make_logger", "logger"]
+
+
+def _initialize_logger() -> logging.Logger:
+    """Initialize the ``noodles`` logger and set its stream handlers."""
+    logger = logging.getLogger("noodles")
+    logger.setLevel(logging.INFO)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(logging.INFO)
+    stream_handler.setFormatter(logging.Formatter(
+        fmt="[%(asctime)s] %(levelname)s: %(message)s",
+        datefmt="%H:%M:%S",
+    ))
+
+    logger.addHandler(stream_handler)
+    return logger
+
+
+logger = _initialize_logger()
 
 
 def _sugar(s):

--- a/noodles/run/process.py
+++ b/noodles/run/process.py
@@ -5,6 +5,7 @@ Process backend
 Run jobs using a process backend.
 """
 
+import logging
 import sys
 import uuid
 from subprocess import Popen, PIPE
@@ -22,6 +23,8 @@ from ..lib import (pull, push, Connection, object_name, EndOfQueue, FlushQueue)
 from .messages import (EndOfWork)
 
 from .remote.io import (JSONObjectReader, JSONObjectWriter)
+
+logger = logging.getLogger("noodles")
 
 
 def process_worker(registry, verbose=False, jobdirs=False,
@@ -49,7 +52,7 @@ def process_worker(registry, verbose=False, jobdirs=False,
     def read_stderr():
         """Read stderr of remote process and sends lines to logger."""
         for line in remote.stderr:
-            print(name + ": " + line.rstrip())
+            logger.info(name + ": " + line.rstrip())
 
     stderr_reader_thread = threading.Thread(target=read_stderr, daemon=True)
     stderr_reader_thread.start()

--- a/noodles/run/worker.py
+++ b/noodles/run/worker.py
@@ -1,6 +1,9 @@
+import logging
 from ..lib import (pull_map, EndOfQueue)
 from .messages import (ResultMessage, JobMessage)
 import sys
+
+logger = logging.getLogger("noodles")
 
 
 @pull_map
@@ -15,8 +18,7 @@ def worker(job):
         return
 
     if not isinstance(job, JobMessage):
-        print("Warning: Job should be communicated using `JobMessage`.",
-              file=sys.stderr)
+        logger.warning("Job should be communicated using `JobMessage`.")
 
     key, node = job
     return run_job(key, node)

--- a/noodles/run/xenon/dynamic_pool.py
+++ b/noodles/run/xenon/dynamic_pool.py
@@ -5,12 +5,15 @@ from ...lib import (
 from ..messages import (
     JobMessage, ResultMessage, EndOfWork)
 
+import logging
 import threading
 import sys
 from collections import namedtuple
 
 from .xenon import (Machine)
 import grpc
+
+logger = logging.getLogger("noodles")
 
 
 def xenon_interactive_worker(
@@ -36,12 +39,12 @@ def xenon_interactive_worker(
     def serialise(obj):
         """Serialise incoming objects, yielding strings."""
         if isinstance(obj, JobMessage):
-            print('serializing:', str(obj.node), file=sys.stderr)
+            logger.info(f'serializing: {obj.node}')
         return (registry.to_json(obj, host='scheduler') + '\n').encode()
 
     @pull_map
     def echo(line):
-        print('{} input: {}'.format(worker_config.name, line), file=sys.stderr)
+        logger.info('{} input: {}'.format(worker_config.name, line))
         return line
 
     def do_iterate(source):
@@ -59,7 +62,7 @@ def xenon_interactive_worker(
     def echo_stderr(text):
         """Print lines."""
         for line in text.split('\n'):
-            print("{}: {}".format(worker_config.name, line), file=sys.stderr)
+            logger.info("{}: {}".format(worker_config.name, line))
 
     if stderr_sink is None:
         stderr_sink = echo_stderr()

--- a/noodles/tutorial.py
+++ b/noodles/tutorial.py
@@ -2,6 +2,7 @@
 Functions useful for tutorial work and unit testing.
 """
 
+import logging
 from inspect import Parameter
 from graphviz import Digraph
 import html
@@ -9,10 +10,12 @@ import sys
 
 from . import schedule, schedule_hint, get_workflow
 
+logger = logging.getLogger("noodles")
+
 
 @schedule
 def echo_add(x, y):
-    print('adding', x, 'and', y, file=sys.stderr)
+    logger.info(f'adding {x} and {y}')
     return x + y
 
 


### PR DESCRIPTION
Closes https://github.com/NLeSC/noodles/issues/85

This PR replaces the various `print` calls throughout the library with equivalent(-ish) `logging.log` calls, the latter having the advantage of greater user-control of the printed output and the which stream(s) are used therefor.

A best effort has been made to pick appropriate logging levels based on contact clues, _.e.g_ a message previously being prefixed with "WARNING: " or, in the case of `CRITICAL`, a message mentioning an internal error and the user should contact the developers. Furthermore, logging messages based on a type of caught exception now also include the exceptions traceback, as these are in my experience extremely usefull when debugging exceptions.